### PR TITLE
fix: Prevent subtract result from having smaller digit of source value

### DIFF
--- a/src/generateKeyBetween.spec.ts
+++ b/src/generateKeyBetween.spec.ts
@@ -23,6 +23,7 @@ describe("generateKeyBetween", () => {
     [null, "a0", null],
     [null, "a0", "a1"],
     [null, "Zz", "a0"],
+    [null, "b0S", "b0T"],
     ["a0", "a4", "a8"],
     ["a0", "a0V", "a1"],
   ])("a:%s mid: %s b:%s", (a, expected, b) => {
@@ -42,6 +43,7 @@ describe("generateJitteredKeyBetween", () => {
     [null, "a06CO", null],
     [null, "a06CO", "a1"],
     [null, "Zz6CO", "a0"],
+    [null, "b0S6CO", "b0T46n"],
     ["a0", "a46CO", "a8"],
     ["a0", "a0V6CO", "a1"],
   ])("a:%s mid: %s b:%s, should not mess up integer part", (a, expected, b) => {

--- a/src/keyAsNumber.spec.ts
+++ b/src/keyAsNumber.spec.ts
@@ -32,14 +32,14 @@ describe("midPoint", () => {
 });
 
 const base62Cases: [a: string, b: string, added: string][] = [
-  ["a0", "1", "a1"],
+  ["a0", "01", "a1"],
   ["1", "a0", "a1"],
-  ["Zz", "1", "a0"],
+  ["Zz", "01", "a0"],
 ];
 
 const base10Cases: [a: string, b: string, added: string][] = [
   ["1", "5", "6"],
-  ["5", "7", "12"],
+  ["5", "07", "12"],
 ];
 
 describe("addCharSetKey", () => {

--- a/src/keyAsNumber.ts
+++ b/src/keyAsNumber.ts
@@ -106,7 +106,7 @@ export function subtractCharSetKeys(
   }
 
   // Remove leading zeros
-  while (result.length > 1 && result[0] === charSet.byCode[0]) {
+  while (result.length > a.length && result[0] === charSet.byCode[0]) {
     result.shift();
   }
 


### PR DESCRIPTION
fix #2

This fix seems to work well for #2 without breaking existing tests.
Thanks!